### PR TITLE
Updated goaccess config file, so it works with goaccess v0.9.4

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 S3 Stat
 =======
 
-This python module uses the really nice `goaccess <http://goaccess.prosoftcorp.com/>` utility
+This python module uses the really nice `goaccess <http://goaccess.io/>` utility
 to provide you with an amazing Amazon log file analyser tool that is relatively easy to install, and is extremely
 easy to extend.
 

--- a/s3stat.py
+++ b/s3stat.py
@@ -3,10 +3,10 @@
 S3 Stat
 =======
 
-This python module uses the really nice `goaccess <http://goaccess.prosoftcorp.com/>`_ utility
+This python module uses the really nice `goaccess <http://goaccess.io/>`_ utility
 to provide you with an amazing Amazon log file analyser tool that is relatively easy to install, and is extremely
 easy to extend.
-GOACCESS version needed: 0.8.5 (it doesn't work with 0.9+)
+GOACCESS version needed: 0.8.5
 
 Installation
 -------------
@@ -23,7 +23,7 @@ Quickstart
 Install goaccess
 .................. 
 
-You should install `goaccess <http://goaccess.prosoftcorp.com/>`_
+You should install `goaccess <http://goaccess.io/>`_
 
 .. note::
     Cloudfront log file processing requires goaccess 0.7.1+

--- a/s3stat.py
+++ b/s3stat.py
@@ -229,11 +229,13 @@ class S3Stat(object):
         if self.is_cloudfront:
             log_content += """
 date_format %Y-%m-%d
+time_format %H:%M:%S
 log_format %d\t%^\t%^\t%b\t%h\t%^\t%^\t%r\t%s\t%R\t%u\t%^
 """
         else:
             log_content += """
 date_format %d/%b/%Y
+time_format %H:%M:%S
 log_format %^ %^ [%d:%^] %h %^ %^ %^ %^ "%^ %r %^" %s %^ %b %^ %^ %^ "%^" "%u" %^
 """
         self.configfile.write(log_content)


### PR DESCRIPTION
The entry "time_format" was missing from the config file, throwing a fatal error:
```
Fatal error has occurred
Error occured at: src/parser.c - verify_formats - 1828
No time format was found on your conf file.
```

Added the entry `time_format %H:%M:%S` to the config file, so it works (again?).
Tested with Cloudfront logfiles and goaccess 0.9.4
